### PR TITLE
Do not ignore 'invalid response'

### DIFF
--- a/price-server/src/lib/error.ts
+++ b/price-server/src/lib/error.ts
@@ -19,10 +19,6 @@ export function init(opts: Options = {}): void {
 }
 
 export function errorHandler(error: Error): void {
-  if (error.message.includes('Invalid response')) {
-    return
-  }
-
   logger.error(error)
   sentry.captureException(error)
 }


### PR DESCRIPTION
I'm sure there was a good reason for this but as it stands, it hides real errors. As a user I prefer to see all errors.

Feel free to ignore if this doesn't align with your vision.