### PR TITLE
Initialize `alivedAt` at the start of the price server

### DIFF
--- a/price-server/src/provider/base/Quoter.ts
+++ b/price-server/src/provider/base/Quoter.ts
@@ -24,7 +24,7 @@ export class Quoter {
 
   private tickedAt: number
   private isAlive = true
-  private alivedAt: number
+  private alivedAt = Date.now()
 
   constructor(options: QuoterOptions) {
     Object.assign(this, { options })


### PR DESCRIPTION
Without this, if the server gets started but never works, it will never
initialize `aliveAt`. In this situation `aliveAt` will be nil, causing
the check in `checkAlive()` to always be true. Therefore it will never
know that it is not alive and never send an error message